### PR TITLE
issue_9 : freeze sur importation avec mysql

### DIFF
--- a/connecthys/application/importation.py
+++ b/connecthys/application/importation.py
@@ -30,7 +30,7 @@ from cryptage import IMPORT_AES, DecrypterFichier
 
 def make_session(connection_string):
     engine = create_engine(connection_string, echo=False, convert_unicode=True)
-    Session = sessionmaker(bind=engine)
+    Session = sessionmaker(bind=engine,autocommit=False)
     return Session(), engine
 
 def quick_mapper(table):
@@ -78,7 +78,8 @@ def Importation(secret=0):
     # Ouvertures des bases
     source, sengine = make_session(from_db)
     smeta = MetaData(bind=sengine)
-    destination, dengine = make_session(to_db)
+    destination = db.session
+    dengine = db.engine
     dmeta = MetaData(bind=dengine)
     
     # Liste des tables à transférer
@@ -107,12 +108,15 @@ def Importation(secret=0):
             u = u.where(table_actions_destination.c.ref_unique == action.ref_unique)
             dengine.execute(u)
         
-        destination.commit()
+    destination.commit()
     
     # Suppression des tables
     for nom_table in tables:
-        dengine.execute("DROP TABLE %s" % "%sportail_%s" % (PREFIXE_TABLES, nom_table))
-    
+        try :
+            dengine.execute("DROP TABLE %s" % "%sportail_%s" % (PREFIXE_TABLES, nom_table))
+        except :
+            pass
+        
     # Création des tables
     db.create_all()
 


### PR DESCRIPTION
On utilise la session flask plutot que de réouvrir une nouvelle connexion a la bd. Cela permet egalement de profiter de la propriete SQLALCHEMY_ECHO sur ces requetes

On commit la session même si la table portail_action ne contient aucune ligne cela evite un lock des metadata sous mysql

testé avec mysql et sqllite