### PR TITLE
Correction pour linux

### DIFF
--- a/connecthys/application/__init__.py
+++ b/connecthys/application/__init__.py
@@ -23,7 +23,7 @@ else:
 
 
 # Récupération du numéro de version de l'application
-import updater
+from . import updater
 __version__ = updater.GetVersionActuelle()
 
 # Init application

--- a/connecthys/application/__init__.py
+++ b/connecthys/application/__init__.py
@@ -16,7 +16,10 @@ from flask_adminlte import AdminLTE
 
 import os.path
 REP_APPLICATION = os.path.abspath(os.path.dirname(__file__))
-REP_CONNECTHYS = os.path.dirname(REP_APPLICATION)
+if sys.platform.startswith('linux'):
+    REP_CONNECTHYS = os.path.dirname(REP_APPLICATION)
+else:
+    REP_CONNECTHYS = os.path.join("/", "var", "log", "connectys")
 
 
 # Récupération du numéro de version de l'application

--- a/connecthys/application/__init__.py
+++ b/connecthys/application/__init__.py
@@ -170,5 +170,5 @@ if config_ok == True :
 # Si configuration absente     
 if config_ok == False :
     AdminLTE(app)
-    import noconfig
+    from . import noconfig
     


### PR DESCRIPTION
Sur Mageia 8, afin de faire démarrer connecthys j'ai du procéder a ces modifications:

1. Changer le dossier des journaux afin que ce ne soit pas dans le dossier de connecthys mais dans /var/log/connecthys ( uniquement sous linux )
2. Correction de l'import du module updater
3. Correction de l'import du module noconfig